### PR TITLE
DTSPO-6371 - add service bus provider

### DIFF
--- a/servicebus.tf
+++ b/servicebus.tf
@@ -1,4 +1,8 @@
 module "servicebus-namespace" {
+  providers = {
+    azurerm.private_endpoint = azurerm.private_endpoint
+  }
+  
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = "${var.product}-${var.env}"
   resource_group_name = azurerm_resource_group.rg.name

--- a/state.tf
+++ b/state.tf
@@ -8,3 +8,10 @@ terraform {
     }
   }
 }
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private_endpoint"
+  subscription_id            = var.aks_subscription_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,5 @@ variable "team_contact" {
   description = "Team contact"
   default     = "#et-tech"
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
# JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6371


### Change description ###
- Service Bus Private endpoint provider added

PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created. 

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module. 

More information on that can be found here: https://github.com/hmcts/terraform-module-servicebus-namespace#usage


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
