### PR TITLE
Update Terraform azurerm version to latest

### DIFF
--- a/state.tf
+++ b/state.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.2.0"
+      version = "~> 3.15.0"
     }
   }
 }


### PR DESCRIPTION
Notes:
This is for Employment Tribunals Release 1.0.0
https://tools.hmcts.net/confluence/display/RSTR/ET-Rel-1.0.0+-+Release+Dashboard

CR: CHG5008762